### PR TITLE
Fix inline style parsing

### DIFF
--- a/component/R.style.js
+++ b/component/R.style.js
@@ -58,7 +58,7 @@ var Style = {
 
         fillColor: {
             get: function () {
-                return this._fillColor || cc.Color.WHITE;
+                return this._fillColor; // || cc.Color.WHITE;
             },
             set: function (value) {
                 this._fillColor = value;

--- a/component/optional/R.svg.js
+++ b/component/optional/R.svg.js
@@ -16,6 +16,26 @@ function toNumberArray (s) {
     return a;
 }
 
+function parseStyle (current, name, value) {
+    if (name === 'fill') {
+        current.fillColor = value === 'none' ? null : cc.hexToColor(value);
+    } else if (name === 'stroke') {
+        current.strokeColor = value === 'none' ? null : cc.hexToColor(value);
+    } else if (name === 'stroke-width') {
+        current.lineWidth = parseFloat(value);
+    } else if (name === 'stroke-linejoin') {
+        current.lineJoin = cc.Graphics.LineJoin[value.toUpperCase()];
+    } else if (name === 'stroke-linecap') {
+        current.lineCap = cc.Graphics.LineCap[value.toUpperCase()];
+    } else if (name === 'stroke-dasharray') {
+        current.dashArray = toNumberArray[value];
+    } else if (name === 'stroke-dashoffset') {
+        current.dashOffset = parseFloat(value);
+    } /* else {
+        cc.log("Unhandled style: " + name + " -- " + value);
+    } */
+}
+
 function parseNode (node, parent) {
     var current;
 
@@ -59,28 +79,14 @@ function parseNode (node, parent) {
                     var name = trim(style[0]);
                     var value = trim(style[1]);
 
-                    if (name === 'fill') {
-                        current.fillColor = value === 'none' ? null : cc.hexToColor(value);
-                    }
-                    else if (name === 'stroke') {
-                        current.strokeColor = value === 'none' ? null : cc.hexToColor(value);
-                    }
-                    else if (name === 'stroke-width') {
-                        current.lineWidth = parseFloat(value);
-                    }
-                    else if (name === 'stroke-linejoin') {
-                        current.lineJoin = cc.Graphics.LineJoin[value.toUpperCase()];
-                    }
-                    else if (name === 'stroke-linecap') {
-                        current.lineCap = cc.Graphics.LineCap[value.toUpperCase()];
-                    }
-                    else if (name === 'stroke-dasharray') {
-                        current.dashArray = toNumberArray[value];
-                    }
-                    else if (name === 'stroke-dashoffset') {
-                        current.dashOffset = parseFloat(value);
-                    }
+                    parseStyle(current, name, value);
                 }
+            }
+        }
+
+        for (var property in node.attribs) {
+            if (node.attribs.hasOwnProperty(property)) {
+                parseStyle(current, property, node.attribs[property]);
             }
         }
     }


### PR DESCRIPTION
Currently, ccc.raphael is broken when parsing nodes of the form:

`<path fill="none" stroke="#f7c562" stroke-width="8" stroke-linecap="round" stroke-linejoin="round" d="M8.767,230.326c0,0,188.246,40.154,196.485-160.139" />`

with inline style attributes on nodes, which are completely ignored. This commit fixes that.